### PR TITLE
task-7: Authorization

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,10 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+.env
+**package-lock.json

--- a/authorization-service/.npmignore
+++ b/authorization-service/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/authorization-service/README.md
+++ b/authorization-service/README.md
@@ -1,0 +1,14 @@
+# Welcome to your CDK TypeScript project
+
+This is a blank project for CDK development with TypeScript.
+
+The `cdk.json` file tells the CDK Toolkit how to execute your app.
+
+## Useful commands
+
+* `npm run build`   compile typescript to js
+* `npm run watch`   watch for changes and compile
+* `npm run test`    perform the jest unit tests
+* `npx cdk deploy`  deploy this stack to your default AWS account/region
+* `npx cdk diff`    compare deployed stack with current state
+* `npx cdk synth`   emits the synthesized CloudFormation template

--- a/authorization-service/bin/authorization-service.ts
+++ b/authorization-service/bin/authorization-service.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { AuthorizationServiceStack } from '../lib/authorization-service-stack';
+
+const app = new cdk.App();
+new AuthorizationServiceStack(app, 'AuthorizationServiceStack', {
+  /* If you don't specify 'env', this stack will be environment-agnostic.
+   * Account/Region-dependent features and context lookups will not work,
+   * but a single synthesized template can be deployed anywhere. */
+
+  /* Uncomment the next line to specialize this stack for the AWS Account
+   * and Region that are implied by the current CLI configuration. */
+  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+
+  /* Uncomment the next line if you know exactly what Account and Region you
+   * want to deploy the stack to. */
+  // env: { account: '123456789012', region: 'us-east-1' },
+
+  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+});

--- a/authorization-service/cdk.json
+++ b/authorization-service/cdk.json
@@ -1,0 +1,72 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/authorization-service.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true,
+    "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeysDefaultValueToFalse": true,
+    "@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2": true,
+    "@aws-cdk/aws-kms:reduceCrossAccountRegionPolicyScope": true,
+    "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
+    "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
+    "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": true,
+    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false
+  }
+}

--- a/authorization-service/jest.config.js
+++ b/authorization-service/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/authorization-service/lambda-functions/basicAuthorizer.ts
+++ b/authorization-service/lambda-functions/basicAuthorizer.ts
@@ -1,0 +1,66 @@
+import {
+  APIGatewayTokenAuthorizerEvent,
+  APIGatewayAuthorizerResult,
+} from "aws-lambda";
+import { Effect } from "aws-cdk-lib/aws-iam";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+export const handler = async (
+  event: APIGatewayTokenAuthorizerEvent
+): Promise<APIGatewayAuthorizerResult> => {
+  console.log(`basicAuthorizerLambda event: ${JSON.stringify(event)}`);
+  let policy: APIGatewayAuthorizerResult;
+
+  try {
+    const { authorizationToken } = event;
+    console.log("+++ authorizationHeaderData", authorizationToken);
+
+    if (!authorizationToken || event.type !== "TOKEN") {
+      policy = generatePolicy(
+        "Unauthorized user",
+        Effect.DENY,
+        event.methodArn
+      );
+      return policy;
+    }
+
+    const token = authorizationToken.split(" ")[1];
+    const encodedToken = Buffer.from(token, "base64").toString("utf-8");
+    const [userName, password] = encodedToken.split("=");
+    const correctPassword = process.env[userName];
+
+    const effect =
+      password !== correctPassword || !correctPassword
+        ? Effect.DENY
+        : Effect.ALLOW;
+    console.log("Effect is ", effect);
+    policy = generatePolicy(userName, effect, event.methodArn);
+
+    return policy;
+  } catch (err) {
+    policy = generatePolicy("Unauthorized user", Effect.DENY, event.methodArn);
+    return policy;
+  }
+};
+
+const generatePolicy = (
+  principalId: string,
+  effect: Effect,
+  resource: string
+): APIGatewayAuthorizerResult => {
+  return {
+    principalId,
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "execute-api:Invoke",
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    },
+  };
+};

--- a/authorization-service/lambda-functions/basicAuthorizer.ts
+++ b/authorization-service/lambda-functions/basicAuthorizer.ts
@@ -28,7 +28,7 @@ export const handler = async (
 
     const token = authorizationToken.split(" ")[1];
     const encodedToken = Buffer.from(token, "base64").toString("utf-8");
-    const [userName, password] = encodedToken.split("=");
+    const [userName, password] = encodedToken.split(":");
     const correctPassword = process.env[userName];
 
     const effect =

--- a/authorization-service/lambda-functions/package.json
+++ b/authorization-service/lambda-functions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "lambda-functions",
+  "version": "1.0.0",
+  "main": "basicAuthorizer.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "aws-cdk-lib": "^2.149.0",
+    "dotenv": "^16.4.5",
+    "path": "^0.12.7"
+  }
+}

--- a/authorization-service/lambda-functions/utils/index.ts
+++ b/authorization-service/lambda-functions/utils/index.ts
@@ -1,0 +1,33 @@
+import { APIGatewayProxyResult } from "aws-lambda";
+
+export const basicHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "*",
+  "Access-Control-Allow-Credentials": true,
+};
+
+export enum HttpStatusCode {
+  OK = 200,
+  BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  FORBIDDEN = 403,
+  NOT_FOUND = 404,
+  METHOD_NOT_ALLOWED = 405,
+  UNPROCESSABLE_CONTENT = 422,
+  INTERNAL_SERVER_ERROR = 500,
+}
+
+export enum ErrorMessages {
+  TOKEN_INVALID = "Invalid token",
+  UNAUTHORIZED = "Unauthorized",
+  FORBIDDEN = "Forbidden",
+}
+
+export const prepareResponse = (
+  statusCode: number,
+  body: any
+): APIGatewayProxyResult => ({
+  statusCode,
+  headers: basicHeaders,
+  body: JSON.stringify(body),
+});

--- a/authorization-service/lib/authorization-service-stack.ts
+++ b/authorization-service/lib/authorization-service-stack.ts
@@ -1,0 +1,29 @@
+import * as cdk from "aws-cdk-lib";
+import { ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Runtime, Function, Code } from "aws-cdk-lib/aws-lambda";
+
+import { Construct } from "constructs";
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+export class AuthorizationServiceStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const basicAuthorizer = new Function(this, "BasicAuthorizerLambda", {
+      runtime: Runtime.NODEJS_20_X,
+      code: Code.fromAsset("lambda-functions"),
+      handler: "basicAuthorizer.handler",
+      environment: {
+        PRODUCT_AWS_REGION: process.env.REGION!,
+      },
+      functionName: "BasicAuthorizerLambda",
+    });
+
+    basicAuthorizer.grantInvoke(
+      new ServicePrincipal("apigateway.amazonaws.com")
+    );
+  }
+}

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "authorization-service",
+  "version": "0.1.0",
+  "bin": {
+    "authorization-service": "bin/authorization-service.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk",
+    "cdk:deploy": "npm run build && cdk deploy"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "20.12.7",
+    "aws-cdk": "2.145.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.4.5"
+  },
+  "dependencies": {
+    "@types/aws-lambda": "^8.10.141",
+    "aws-cdk-lib": "2.145.0",
+    "constructs": "^10.0.0",
+    "dotenv": "^16.4.5",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/authorization-service/test/authorization-service.test.ts
+++ b/authorization-service/test/authorization-service.test.ts
@@ -1,0 +1,17 @@
+// import * as cdk from 'aws-cdk-lib';
+// import { Template } from 'aws-cdk-lib/assertions';
+// import * as AuthorizationService from '../lib/authorization-service-stack';
+
+// example test. To run these tests, uncomment this file along with the
+// example resource in lib/authorization-service-stack.ts
+test('SQS Queue Created', () => {
+//   const app = new cdk.App();
+//     // WHEN
+//   const stack = new AuthorizationService.AuthorizationServiceStack(app, 'MyTestStack');
+//     // THEN
+//   const template = Template.fromStack(stack);
+
+//   template.hasResourceProperties('AWS::SQS::Queue', {
+//     VisibilityTimeout: 300
+//   });
+});

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}

--- a/import-service/lambda-functions/utils/index.ts
+++ b/import-service/lambda-functions/utils/index.ts
@@ -10,6 +10,8 @@ export const catalogItemsQueueArn =
 export const catalogItemsQueueUrl =
   process.env.QUEUE_URL ??
   "https://sqs.eu-west-1.amazonaws.com/654654438735/catalog-items-queue";
+export const basicAuthorizerFuncName =
+  process.env.BASIC_AUTHORIZER_FUNC_NAME || "BasicAuthorizerLambda";
 
 export const basicHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -18,9 +20,15 @@ export const basicHeaders = {
     "Content-Type, X-Amz-Date, Authorization, X-Api-Key, X-Amz-Security-Token",
 };
 
+export const authorizerHeaders = {
+  "Access-Control-Allow-Origin": "'*'",
+};
+
 export enum HttpStatusCode {
   OK = 200,
   BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  FORBIDDEN = 403,
   NOT_FOUND = 404,
   METHOD_NOT_ALLOWED = 405,
   UNPROCESSABLE_CONTENT = 422,

--- a/import-service/lib/import-service-stack.ts
+++ b/import-service/lib/import-service-stack.ts
@@ -1,17 +1,27 @@
 import * as cdk from "aws-cdk-lib";
-import * as lambda from "aws-cdk-lib/aws-lambda";
-import { Cors, LambdaIntegration, RestApi } from "aws-cdk-lib/aws-apigateway";
-import { HttpMethod, Runtime } from "aws-cdk-lib/aws-lambda";
+import {
+  Cors,
+  IdentitySource,
+  LambdaIntegration,
+  ResponseType,
+  RestApi,
+  TokenAuthorizer,
+} from "aws-cdk-lib/aws-apigateway";
+import { HttpMethod, Runtime, Function, Code } from "aws-cdk-lib/aws-lambda";
 import { Bucket, EventType } from "aws-cdk-lib/aws-s3";
 import { LambdaDestination } from "aws-cdk-lib/aws-s3-notifications";
 import { Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import {
+  authorizerHeaders,
+  basicAuthorizerFuncName,
   bucketName,
   catalogItemsQueueArn,
+  HttpStatusCode,
   prefix,
   region,
 } from "../lambda-functions/utils";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 
 export class ImportServiceStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -23,35 +33,32 @@ export class ImportServiceStack extends cdk.Stack {
       "CatalogItemsQueue",
       catalogItemsQueueArn
     );
-
-    const importProductsFile = new lambda.Function(
+    const basicAuthorizerFunction = Function.fromFunctionName(
       this,
-      "importProductsFileLambda",
-      {
-        runtime: Runtime.NODEJS_20_X,
-        code: lambda.Code.fromAsset("lambda-functions"),
-        handler: "importProductsFile.handler",
-        environment: {
-          PRODUCT_AWS_REGION: region,
-          BUCKET_NAME: bucket.bucketName,
-        },
-      }
+      "BasicAuthorizerLambda",
+      basicAuthorizerFuncName
     );
 
-    const importFileParser = new lambda.Function(
-      this,
-      "importFileParserLambda",
-      {
-        runtime: Runtime.NODEJS_20_X,
-        code: lambda.Code.fromAsset("lambda-functions"),
-        handler: "importFileParser.handler",
-        environment: {
-          PRODUCT_AWS_REGION: region,
-          BUCKET_NAME: bucket.bucketName,
-          QUEUE_URL: queue.queueUrl,
-        },
-      }
-    );
+    const importProductsFile = new Function(this, "importProductsFileLambda", {
+      runtime: Runtime.NODEJS_20_X,
+      code: Code.fromAsset("lambda-functions"),
+      handler: "importProductsFile.handler",
+      environment: {
+        PRODUCT_AWS_REGION: region,
+        BUCKET_NAME: bucket.bucketName,
+      },
+    });
+
+    const importFileParser = new Function(this, "importFileParserLambda", {
+      runtime: Runtime.NODEJS_20_X,
+      code: Code.fromAsset("lambda-functions"),
+      handler: "importFileParser.handler",
+      environment: {
+        PRODUCT_AWS_REGION: region,
+        BUCKET_NAME: bucket.bucketName,
+        QUEUE_URL: queue.queueUrl,
+      },
+    });
 
     const api = new RestApi(this, "importApi", {
       restApiName: "Import API",
@@ -59,10 +66,41 @@ export class ImportServiceStack extends cdk.Stack {
         allowOrigins: Cors.ALL_ORIGINS,
         allowHeaders: Cors.DEFAULT_HEADERS,
         allowMethods: Cors.ALL_METHODS,
+        allowCredentials: true,
       },
     });
 
     const importResource = api.root.addResource("import");
+
+    api.addGatewayResponse("ImportProductsFileUnauthorized", {
+      type: ResponseType.UNAUTHORIZED,
+      statusCode: `${HttpStatusCode.UNAUTHORIZED}`,
+      responseHeaders: authorizerHeaders,
+    });
+
+    api.addGatewayResponse("ImportProductsFileForbidden", {
+      type: ResponseType.ACCESS_DENIED,
+      statusCode: `${HttpStatusCode.FORBIDDEN}`,
+      responseHeaders: authorizerHeaders,
+    });
+
+    const authRole = new Role(this, "ImportProductsFileAuthorizerRole", {
+      assumedBy: new ServicePrincipal("apigateway.amazonaws.com"),
+    });
+
+    authRole.addToPolicy(
+      new PolicyStatement({
+        actions: ["lambda:InvokeFunction"],
+        resources: [basicAuthorizerFunction.functionArn],
+      })
+    );
+
+    const authorizer = new TokenAuthorizer(this, "ApiAuthorizer", {
+      handler: basicAuthorizerFunction,
+      assumeRole: authRole,
+      identitySource: IdentitySource.header("Authorization"),
+    });
+
     importResource.addMethod(
       HttpMethod.GET,
       new LambdaIntegration(importProductsFile),
@@ -73,6 +111,7 @@ export class ImportServiceStack extends cdk.Stack {
         requestValidatorOptions: {
           validateRequestParameters: true,
         },
+        authorizer: authorizer,
       }
     );
 


### PR DESCRIPTION
# task-7: Authorization
Cloudfront link: https://dewycxcozduah.cloudfront.net/
## Task 7.1-7.4
Evaluation criteria (70 points for covering all criteria)
- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct AWS CDK Stack
- [x] Import Service AWS CDK Stack has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)
## Additional (optional) tasks
- [x] +30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.
FE PR link: https://github.com/likhanna/nodejs-aws-shop-react/pull/4
### Total: 100/100